### PR TITLE
Clarify commands availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The plugin provides three methods for quickly displaying CMake documentation:
 `{arg}` can be any standard CMake keyword. Use <kbd>TAB</kbd> in command-line
 mode for argument completion and to get a list of supported keywords.
 
+These commands are all buffer local and only available with `filetype=cmake`.
+
 #### Example
 
 To open the CMake documentation for the word under the cursor in a popup window with

--- a/doc/cmakehelp.txt
+++ b/doc/cmakehelp.txt
@@ -41,6 +41,8 @@ Commands ~
             https://cmake.org/cmake/help/vX.YY, where X.YY denotes the version
             of the CMake executable specified in |cmakehelp.exe|.
 
+Above commands are all buffer local, available only with `filetype=cmake`.
+
 Mappings ~
 
 <plug>(cmake-help)                                        *<plug>(cmake-help)*


### PR DESCRIPTION
Sooner or later everyone will try using this plugin with an actual file, but its better to explicitly document availability. Especially with `:help CMakeHelp` et cetera working directly after following instructions, while the actual commands might appear to fail when validating whether installation worked.